### PR TITLE
Consider parsing fractional shares

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -15,7 +15,7 @@ RECORD_FUND_TRANSFER = re.compile(r"(Cash Transfer)|(Electronic Fund Transfer)|(
 RECORD_DIVIDEND = re.compile(r"Cash Dividend|Payment in Lieu of Dividend")
 RECORD_INTEREST = re.compile(r"Credit|Debit Interest|IBKR Managed Securities \(SYEP\) Interest")
 RECORD_OPTION = re.compile(r"(Buy|Sell) (-?[0-9,]+) (.{1,5} [0-9]{2}(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)[0-9]{2} [0-9]+(\.[0-9]+)? ([PC])) (\(\w+\))?")
-RECORD_SHARES = re.compile(r"(Buy|Sell) (-?[0-9,]+) (.*?)\s*(\(\w+\))?$")
+RECORD_SHARES = re.compile(r"(Buy|Sell) (-?[0-9,]+[0-9\.]*) ([\w\ ]+)")
 RECORD_FOREX = re.compile(r"Forex Trade")
 RECORD_MARKET_DATA_SUBSCRIPTION = re.compile(r"[A-Za-z]\*{6,}[0-9]{2}:")
 
@@ -57,7 +57,7 @@ def categorize_statement_record(record: pd.Series) -> str:
 @dataclass
 class FinancialAction:
     action: str
-    count: int
+    count: float
     name: str
 
 
@@ -67,11 +67,11 @@ def parse_option_share_record(record: pd.Series) -> dict:
     if match is not None:
         # Cleansing: Remove ending .0 from strike price as some options have this precision specification and some not
         name = re.sub(r"(.*?)(\.0)( [CP])", r"\1\3", match.group(3))
-        return asdict(FinancialAction(match.group(1), int(match.group(2).replace(",", "")), name))
+        return asdict(FinancialAction(match.group(1), float(match.group(2).replace(",", "")), name))
 
     match = RECORD_SHARES.match(description)
     if match is not None:
-        return asdict(FinancialAction(match.group(1), int(match.group(2).replace(",", "")), match.group(3)))
+        return asdict(FinancialAction(match.group(1), float(match.group(2).replace(",", "")), match.group(3)))
 
 
 class DividendType(Enum):


### PR DESCRIPTION
 + Fractional shares were being ignored from the parsing, resulting in the unknown category. This fixes the regex and the financial action to a float to encompass fractional shares